### PR TITLE
fixed bug to return only related table data in join

### DIFF
--- a/sqlalchemy_celery_beat/models.py
+++ b/sqlalchemy_celery_beat/models.py
@@ -283,7 +283,10 @@ def setup_listener(mapper, class_):
         ),
         backref=backref(
             "model_%s" % discriminator,
-            primaryjoin=remote(class_.id) == foreign(PeriodicTask.schedule_id),
+             primaryjoin=sa.and_(
+                remote(class_.id) == foreign(PeriodicTask.schedule_id),
+                PeriodicTask.discriminator == discriminator,
+            ),
             viewonly=True,
             lazy='selectin'
         ),

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -660,6 +660,27 @@ class test_models(SchedulerCase):
         assert isdue2 is True  # True means task is due and should run.
         assert (nextcheck2 == NEVER_CHECK_TIMEOUT) and (isdue2 is True)
 
+    def test_PeriodicTask_specifyjoin(self):
+        p = self.create_model_interval(self.session, schedule(timedelta(seconds=3)))
+        c = self.create_model_crontab(self.session, crontab(minute="3", hour="3"))
+
+        self.session.add(p)
+        self.session.add(c)
+        self.session.commit()
+
+        p = self.session.query(PeriodicTask).first()
+
+        assert p.schedule_id == 1
+        assert c.schedule_id == 1
+
+        assert p.discriminator == 'intervalschedule'
+        assert p.model_crontabschedule is None
+        assert p.model_intervalschedule is not None
+
+        assert c.discriminator == 'crontabschedule'
+        assert c.model_crontabschedule is not None
+        assert c.model_intervalschedule is None
+
 
 class test_model_PeriodicTaskChanged(SchedulerCase):
 


### PR DESCRIPTION
# Feature re: Select Periodic Task joined with discriminator table

## Expected Behavior
When querying on PeriodicTask table using `session.query(PeriodicTask)`, the joined schedule table is related to the schedule_id AND the discriminator.

## Actual Behavior
When querying, if the same id exists in both schedule tables, both joined tables are returned.

## Test sample
```python
    def test_PeriodicTask_specifyjoin(self):
        p = self.create_model_interval(self.session, schedule(timedelta(seconds=3)))
        c = self.create_model_crontab(self.session, crontab(minute="3", hour="3"))

        self.session.add(p)
        self.session.add(c)
        self.session.commit()

        p = self.session.query(PeriodicTask).first()

        assert p.schedule_id == 1
        assert c.schedule_id == 1

        assert p.discriminator == 'intervalschedule'
        assert p.model_crontabschedule is None # this would fail prior to these changes
        assert p.model_intervalschedule is not None

        assert c.discriminator == 'crontabschedule'
        assert c.model_intervalschedule is None # this would fail as well
        assert c.model_crontabschedule is not None 
```

## Thoughts
In the older implementation (celery_sqlalchemy_scheduler), there were two separate foreign keys specifically connected by crontab_id and interval_id. The newer version uses the discriminator column and the reasoning behind this seems vague.

## Collaborators
[Matthew Bronstein](https://github.com/mbronstein1)
[Bazyl Horsey](https://github.com/bazylhorsey)
