### PR TITLE
Fix crontab syntax in print

### DIFF
--- a/sqlalchemy_celery_beat/tzcrontab.py
+++ b/sqlalchemy_celery_beat/tzcrontab.py
@@ -23,7 +23,7 @@ class TzAwareCrontab(schedules.crontab):
         self.tz = tz
 
         nowfun = self.nowfunc
-        print(f'{minute} {hour} {day_of_week} {day_of_month} {month_of_year} {tz}')
+        print(f'{minute} {hour} {day_of_month} {month_of_year} {day_of_week} {tz}')
         super(TzAwareCrontab, self).__init__(
             minute=minute, hour=hour, day_of_week=day_of_week,
             day_of_month=day_of_month, month_of_year=month_of_year,

--- a/sqlalchemy_celery_beat/tzcrontab.py
+++ b/sqlalchemy_celery_beat/tzcrontab.py
@@ -58,8 +58,8 @@ class TzAwareCrontab(schedules.crontab):
     # Needed to support pickling
     def __repr__(self):
         return """<crontab: {0._orig_minute} {0._orig_hour} \
-{0._orig_day_of_week} {0._orig_day_of_month} \
-{0._orig_month_of_year} (m/h/d/dM/MY), {0.tz}>""".format(self)
+{0._orig_day_of_month} {0._orig_month_of_year} \
+{0._orig_day_of_week} (m/h/dM/MY/d), {0.tz}>""".format(self)
 
     def __reduce__(self):
         return (self.__class__, (self._orig_minute,


### PR DESCRIPTION
Updates the print call to ensure better alignment with the standard crontab syntax:

```
# * * * * * <command to execute>
# | | | | |
# | | | | day of the week (0–6) (Sunday to Saturday; 7 is also Sunday on some systems)
# | | | month (1–12)
# | | day of the month (1–31)
# | hour (0–23)
# minute (0–59)
```

This fix should reduce potential errors in understanding or debugging crontab schedules (like I did, that's why I'm here opening this PR 😄 )