### PR TITLE
fix: Use datetime.timezone for timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A Scheduler Based Sqlalchemy for Celery.
 
 > NOTE: This project was originally developed by [AngelLiang](https://github.com/AngelLiang/celery-sqlalchemy-scheduler) to use sqlalchemy as the database scheduler for Flask or FastAPI, like [django-celery-beat](https://github.com/celery/django-celery-beat) for django. I am trying to continue on his work and maintain a working solution.
 
-
 ### Prerequisites
 
 - Python 3
@@ -50,7 +49,9 @@ This is a demo for exmaple, you can check the code in `examples` directory
    ```
    $ celery -A tasks beat -S sqlalchemy_celery_beat.schedulers:DatabaseScheduler -l info
    ```
-    you can also use the shorthand argument `-S sqlalchemy`
+
+   you can also use the shorthand argument `-S sqlalchemy`
+
 ## Description
 
 After the celery beat is started, by default it create a sqlite database(`schedule.db`) in current folder. You can use `SQLiteStudio.exe` to inspect it.
@@ -91,6 +92,7 @@ beat_dburi = 'postgresql+psycopg2://postgres:postgres@127.0.0.1:5432/celery-sche
 ```
 
 ## Passing arguments to SQLAlchemy engine creation
+
 You can pass arguments using the `beat_engine_options` keyword in the config dictionary, for example let's make the engine use `echo=True` to show verbose ouptut:
 
 ```python
@@ -104,12 +106,12 @@ celery.conf.update(
     }
 )
 ```
+
 You can use this to pass any options required by your DB driver, for more information about what options you can use check the SQLAlchemy docs.
 
 ## Example Code 1
 
 View `examples/base/tasks.py` for details.
-
 
 Run Worker in console 1
 
@@ -189,7 +191,7 @@ Here\'s an example specifying the arguments, note how JSON serialization
 is required:
 
     >>> import json
-    >>> from datetime import datetime, timedelta, UTC
+    >>> from datetime import datetime, timedelta, timezone
 
     >>> periodic_task = PeriodicTask(
     ...     schedule_model=schedule,                  # we created this above.
@@ -199,7 +201,7 @@ is required:
     ...     kwargs=json.dumps({
     ...        'be_careful': True,
     ...     }),
-    ...     expires=datetime.now(UTC) + timedelta(seconds=30)
+    ...     expires=datetime.now(timezone.utc) + timedelta(seconds=30)
     ... )
     ... session.add(periodic_task)
     ... session.commit()
@@ -241,6 +243,7 @@ What the previous code actually do is this:
     ...     name='Importing contacts',
     ...     task='proj.tasks.import_contacts',
     ... )
+
 So when you can use `discriminator` + `schedule_id` or use the convenient property `schedule_model` and it will populate them for you behind the scenes.
 
 ### Temporarily disable a periodic task
@@ -254,7 +257,8 @@ You can use the `enabled` flag to temporarily disable a periodic task:
 If you are using a bulk operation to update or delete multiple tasks at the same time, the changes won't be noticed by the scheduler until you do `PeriodicTaskChanged.update_changed()` or `.update_from_session()`
 
 example:
-``` python
+
+```python
 from sqlalchemy_celery_beat.models import PeriodicTaskChanged
 from sqlalchemy_celery_beat.session import SessionManager, session_cleanup
 
@@ -270,6 +274,7 @@ with session_cleanup(session):
     PeriodicTaskChanged.update_from_session(session)
     # now scheduler reloads the tasks and all is good
 ```
+
 This is not needed when you are updating a specific object using `session.add(task)` because it will trigger the `after_update`, `after_delete` or `after_insert` events.
 
 ### Example running periodic tasks

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ is required:
     ...     kwargs=json.dumps({
     ...        'be_careful': True,
     ...     }),
-    ...     expires=datetime.now(timezone.utc) + timedelta(seconds=30)
+    ...     expires=datetime.now(tz=timezone.utc) + timedelta(seconds=30)
     ... )
     ... session.add(periodic_task)
     ... session.commit()

--- a/examples/base/tasks.py
+++ b/examples/base/tasks.py
@@ -109,7 +109,7 @@ beat_schedule = {
         'schedule': timedelta(seconds=3),
         'args': ('hello', ),
         'options': {
-            'expires': dt.datetime.now(dt.timezone.utc) + timedelta(seconds=10)  # right
+            'expires': dt.datetime.now(tz=dt.timezone.utc) + timedelta(seconds=10)  # right
             # 'expires': dt.datetime.now() + timedelta(seconds=30)  # error
             # 'expires': 10  # right
         }
@@ -131,7 +131,7 @@ beat_schedule = {
     },
     'echo-at-clock-time': {
         'task': 'tasks.echo',
-        'schedule': clocked(dt.datetime.now(dt.timezone.utc) + timedelta(minutes=5)),
+        'schedule': clocked(dt.datetime.now(tz=dt.timezone.utc) + timedelta(minutes=5)),
         'args': ('hello from the clock', ),
         'options':{'one_off': True}
     },

--- a/examples/base/tasks.py
+++ b/examples/base/tasks.py
@@ -109,7 +109,7 @@ beat_schedule = {
         'schedule': timedelta(seconds=3),
         'args': ('hello', ),
         'options': {
-            'expires': dt.datetime.now(dt.UTC) + timedelta(seconds=10)  # right
+            'expires': dt.datetime.now(dt.timezone.utc) + timedelta(seconds=10)  # right
             # 'expires': dt.datetime.now() + timedelta(seconds=30)  # error
             # 'expires': 10  # right
         }
@@ -131,7 +131,7 @@ beat_schedule = {
     },
     'echo-at-clock-time': {
         'task': 'tasks.echo',
-        'schedule': clocked(dt.datetime.now(dt.UTC) + timedelta(minutes=5)),
+        'schedule': clocked(dt.datetime.now(dt.timezone.utc) + timedelta(minutes=5)),
         'args': ('hello from the clock', ),
         'options':{'one_off': True}
     },

--- a/sqlalchemy_celery_beat/models.py
+++ b/sqlalchemy_celery_beat/models.py
@@ -68,7 +68,7 @@ class PeriodicTaskChanged(ModelBase, ModelMixin):
 
     id = sa.Column(sa.Integer, primary_key=True)
     last_update = sa.Column(
-        sa.DateTime(timezone=True), nullable=False, default=lambda: maybe_make_aware(dt.datetime.now(dt.timezone.utc)))
+        sa.DateTime(timezone=True), nullable=False, default=lambda: maybe_make_aware(dt.datetime.now(tz=dt.timezone.utc)))
 
     @classmethod
     def changed(cls, mapper, connection, target):
@@ -92,11 +92,11 @@ class PeriodicTaskChanged(ModelBase, ModelMixin):
                               where(PeriodicTaskChanged.id == 1).limit(1))
         if not s:
             s = connection.execute(insert(PeriodicTaskChanged).
-                                   values(id=1, last_update=maybe_make_aware(dt.datetime.now(dt.timezone.utc))))
+                                   values(id=1, last_update=maybe_make_aware(dt.datetime.now(tz=dt.timezone.utc))))
         else:
             s = connection.execute(update(PeriodicTaskChanged).
                                    where(PeriodicTaskChanged.id == 1).
-                                   values(last_update=maybe_make_aware(dt.datetime.now(dt.timezone.utc))))
+                                   values(last_update=maybe_make_aware(dt.datetime.now(tz=dt.timezone.utc))))
 
     @classmethod
     def update_from_session(cls, session: Session, commit: bool = True):
@@ -192,8 +192,8 @@ class PeriodicTask(ModelBase, ModelMixin):
                                 'has triggered the task')
 
     date_changed = sa.Column(sa.DateTime(timezone=True),
-                             default=lambda: maybe_make_aware(dt.datetime.now(dt.timezone.utc)),
-                             onupdate=lambda: maybe_make_aware(dt.datetime.now(dt.timezone.utc)),
+                             default=lambda: maybe_make_aware(dt.datetime.now(tz=dt.timezone.utc)),
+                             onupdate=lambda: maybe_make_aware(dt.datetime.now(tz=dt.timezone.utc)),
                              doc='Last Modified',
                              comment='Datetime that this PeriodicTask was last modified')
     description = sa.Column(sa.Text(), default='', doc='Description',
@@ -467,7 +467,7 @@ class CrontabSchedule(ScheduleModel, ModelBase):
             for k in ('minute', 'hour', 'day_of_week', 'day_of_month', 'month_of_year'):
                 setattr(target, k, CrontabSchedule.cronexp(getattr(target, k)))
             # Test the object to make sure it is valid before saving to DB
-            CrontabSchedule.aware_crontab(target).remaining_estimate(dt.datetime.now(dt.timezone.utc))
+            CrontabSchedule.aware_crontab(target).remaining_estimate(dt.datetime.now(tz=dt.timezone.utc))
         except Exception as exc:
             raise ValueError(f"Could not parse cron {target}: {str(exc)}") from exc
 
@@ -511,7 +511,7 @@ class SolarSchedule(ScheduleModel, ModelBase):
             self.event,
             self.latitude,
             self.longitude,
-            nowfun=lambda: maybe_make_aware(dt.datetime.now(dt.timezone.utc))
+            nowfun=lambda: maybe_make_aware(dt.datetime.now(tz=dt.timezone.utc))
         )
 
     @classmethod

--- a/sqlalchemy_celery_beat/models.py
+++ b/sqlalchemy_celery_beat/models.py
@@ -68,7 +68,7 @@ class PeriodicTaskChanged(ModelBase, ModelMixin):
 
     id = sa.Column(sa.Integer, primary_key=True)
     last_update = sa.Column(
-        sa.DateTime(timezone=True), nullable=False, default=lambda: maybe_make_aware(dt.datetime.now(dt.UTC)))
+        sa.DateTime(timezone=True), nullable=False, default=lambda: maybe_make_aware(dt.datetime.now(dt.timezone.utc)))
 
     @classmethod
     def changed(cls, mapper, connection, target):
@@ -92,11 +92,11 @@ class PeriodicTaskChanged(ModelBase, ModelMixin):
                               where(PeriodicTaskChanged.id == 1).limit(1))
         if not s:
             s = connection.execute(insert(PeriodicTaskChanged).
-                                   values(id=1, last_update=maybe_make_aware(dt.datetime.now(dt.UTC))))
+                                   values(id=1, last_update=maybe_make_aware(dt.datetime.now(dt.timezone.utc))))
         else:
             s = connection.execute(update(PeriodicTaskChanged).
                                    where(PeriodicTaskChanged.id == 1).
-                                   values(last_update=maybe_make_aware(dt.datetime.now(dt.UTC))))
+                                   values(last_update=maybe_make_aware(dt.datetime.now(dt.timezone.utc))))
 
     @classmethod
     def update_from_session(cls, session: Session, commit: bool = True):
@@ -192,8 +192,8 @@ class PeriodicTask(ModelBase, ModelMixin):
                                 'has triggered the task')
 
     date_changed = sa.Column(sa.DateTime(timezone=True),
-                             default=lambda: maybe_make_aware(dt.datetime.now(dt.UTC)),
-                             onupdate=lambda: maybe_make_aware(dt.datetime.now(dt.UTC)),
+                             default=lambda: maybe_make_aware(dt.datetime.now(dt.timezone.utc)),
+                             onupdate=lambda: maybe_make_aware(dt.datetime.now(dt.timezone.utc)),
                              doc='Last Modified',
                              comment='Datetime that this PeriodicTask was last modified')
     description = sa.Column(sa.Text(), default='', doc='Description',
@@ -467,7 +467,7 @@ class CrontabSchedule(ScheduleModel, ModelBase):
             for k in ('minute', 'hour', 'day_of_week', 'day_of_month', 'month_of_year'):
                 setattr(target, k, CrontabSchedule.cronexp(getattr(target, k)))
             # Test the object to make sure it is valid before saving to DB
-            CrontabSchedule.aware_crontab(target).remaining_estimate(dt.datetime.now(dt.UTC))
+            CrontabSchedule.aware_crontab(target).remaining_estimate(dt.datetime.now(dt.timezone.utc))
         except Exception as exc:
             raise ValueError(f"Could not parse cron {target}: {str(exc)}") from exc
 
@@ -511,7 +511,7 @@ class SolarSchedule(ScheduleModel, ModelBase):
             self.event,
             self.latitude,
             self.longitude,
-            nowfun=lambda: maybe_make_aware(dt.datetime.now(dt.UTC))
+            nowfun=lambda: maybe_make_aware(dt.datetime.now(dt.timezone.utc))
         )
 
     @classmethod

--- a/sqlalchemy_celery_beat/schedulers.py
+++ b/sqlalchemy_celery_beat/schedulers.py
@@ -158,7 +158,7 @@ class ModelEntry(ScheduleEntry):
         return self.schedule.is_due(self.last_run_at)
 
     def _default_now(self):
-        now = maybe_make_aware(dt.datetime.now(dt.timezone.utc))
+        now = maybe_make_aware(dt.datetime.now(tz=dt.timezone.utc))
         return now
 
     def __next__(self):
@@ -267,7 +267,7 @@ class ModelEntry(ScheduleEntry):
             if isinstance(expires, int):
                 data['expire_seconds'] = expires
             elif isinstance(expires, dt.timedelta):
-                data['expires'] = dt.datetime.now(dt.timezone.utc) + expires
+                data['expires'] = dt.datetime.now(tz=dt.timezone.utc) + expires
         return data
 
     def __repr__(self):

--- a/sqlalchemy_celery_beat/schedulers.py
+++ b/sqlalchemy_celery_beat/schedulers.py
@@ -158,7 +158,7 @@ class ModelEntry(ScheduleEntry):
         return self.schedule.is_due(self.last_run_at)
 
     def _default_now(self):
-        now = maybe_make_aware(dt.datetime.now(dt.UTC))
+        now = maybe_make_aware(dt.datetime.now(dt.timezone.utc))
         return now
 
     def __next__(self):
@@ -267,7 +267,7 @@ class ModelEntry(ScheduleEntry):
             if isinstance(expires, int):
                 data['expire_seconds'] = expires
             elif isinstance(expires, dt.timedelta):
-                data['expires'] = dt.datetime.now(dt.UTC) + expires
+                data['expires'] = dt.datetime.now(dt.timezone.utc) + expires
         return data
 
     def __repr__(self):

--- a/sqlalchemy_celery_beat/tzcrontab.py
+++ b/sqlalchemy_celery_beat/tzcrontab.py
@@ -34,7 +34,7 @@ class TzAwareCrontab(schedules.crontab):
     def nowfunc(self):
         return normalize(
             self.tz,
-            localize(ZoneInfo('UTC'), dt.datetime.now(dt.UTC).replace(tzinfo=None))
+            localize(ZoneInfo('UTC'), dt.datetime.now(dt.timezone.utc).replace(tzinfo=None))
         )
 
     def is_due(self, last_run_at):

--- a/sqlalchemy_celery_beat/tzcrontab.py
+++ b/sqlalchemy_celery_beat/tzcrontab.py
@@ -34,7 +34,7 @@ class TzAwareCrontab(schedules.crontab):
     def nowfunc(self):
         return normalize(
             self.tz,
-            localize(ZoneInfo('UTC'), dt.datetime.now(dt.timezone.utc).replace(tzinfo=None))
+            localize(ZoneInfo('UTC'), dt.datetime.now(tz=dt.timezone.utc).replace(tzinfo=None))
         )
 
     def is_due(self, last_run_at):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,14 +99,14 @@ class test_ClockedScheduleTestCase(TestDuplicatesMixin, TestMixin):
         self.app.conf.timezone = 'Africa/Cairo'
 
     def test_duplicate_schedules(self):
-        now = make_aware(datetime.datetime.now(datetime.timezone.utc), ZoneInfo('UTC'))
+        now = make_aware(datetime.datetime.now(tz=datetime.timezone.utc), ZoneInfo('UTC'))
         kwargs = {'clocked_time': now}
         self._test_duplicate_schedules(ClockedSchedule, self.session, kwargs)
 
     # IMPORTANT: we must have a valid timezone (not UTC) for accurate testing
     def test_timezone_format(self, set_timezone):
         """Ensure scheduled time is not shown in UTC when timezone is used"""
-        tz_info = datetime.datetime.now(ZoneInfo(self.app.conf.timezone))
+        tz_info = datetime.datetime.now(tz=ZoneInfo(self.app.conf.timezone))
         with session_cleanup(self.session):
             schedule = self.session.query(ClockedSchedule).filter_by(clocked_time=tz_info).first()
             if not schedule:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,7 +99,7 @@ class test_ClockedScheduleTestCase(TestDuplicatesMixin, TestMixin):
         self.app.conf.timezone = 'Africa/Cairo'
 
     def test_duplicate_schedules(self):
-        now = make_aware(datetime.datetime.now(datetime.UTC), ZoneInfo('UTC'))
+        now = make_aware(datetime.datetime.now(datetime.timezone.utc), ZoneInfo('UTC'))
         kwargs = {'clocked_time': now}
         self._test_duplicate_schedules(ClockedSchedule, self.session, kwargs)
 


### PR DESCRIPTION
I just updated to v0.8.2 on Python 3.10, which pulled in e81799a4804fba599adbcd34ed7af78bd0ba50ec. That commit doesn't work with Python 3.9 or 3.10, which are currently supported by this package.

`datetime.UTC` was added in Python 3.11: https://docs.python.org/3/library/datetime.html#datetime.UTC
`datetime.timezone` has been available since Python 3.2: https://docs.python.org/3/library/datetime.html#datetime.timezone

I verified that this works on both Python 3.9 and 3.11. (Running the 3.9 tests on `main` shows that they're failing for the same reason.)

Tests:
```sh
uv venv --python 3.9
uv pip install -r requirements.txt
uv pip install -r testing_requirements.txt
uv run pytest
```

```sh
uv venv --python 3.11
uv pip install -r requirements.txt
uv pip install -r testing_requirements.txt
uv run pytest
```


That results in 3 tests failing, which are also failing on `main` and unrelated to the changes in this PR. Happy to take a stab at fixing those in a follow-up. I didn't want to touch them here since they are unrelated changes.