### PR TITLE
Import declarative_base from sqlalchemy.orm to avoid deprecation (#22)

### DIFF
--- a/sqlalchemy_celery_beat/session.py
+++ b/sqlalchemy_celery_beat/session.py
@@ -8,8 +8,8 @@ from celery.utils.time import get_exponential_backoff_interval
 from kombu.utils.compat import register_after_fork
 from sqlalchemy import DDL, Column, Integer, create_engine
 from sqlalchemy.exc import DatabaseError
-from sqlalchemy.ext.declarative import declarative_base, declared_attr
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.pool import NullPool
 
 # from sqlalchemy.schema import CreateSchema  # does not work for SA 1.4


### PR DESCRIPTION
Fixes #22 and works on SQLAlchemy >= 1.4.0.