### PR TITLE
Handle the exception DBAPIError thrown when the database is not available

### DIFF
--- a/sqlalchemy_celery_beat/schedulers.py
+++ b/sqlalchemy_celery_beat/schedulers.py
@@ -428,10 +428,14 @@ class DatabaseScheduler(Scheduler):
             logger.debug('DatabaseScheduler: initial read')
             initial = update = True
             self._initial_read = False
-        elif self.schedule_changed():
-            # when you updated the `PeriodicTasks` model's `last_update` field
-            logger.info('DatabaseScheduler: Schedule changed.')
-            update = True
+        else:
+            try:
+                if self.schedule_changed():
+                    update = True
+                    # when you updated the `PeriodicTasks` model's `last_update` field
+                    logger.info('DatabaseScheduler: Schedule changed.')
+            except sa.exc.DBAPIError as exc:
+                logger.exception('Database error while checking if the schedule changed: %r', exc)
 
         if update:
             self.sync()

--- a/sqlalchemy_celery_beat/schedulers.py
+++ b/sqlalchemy_celery_beat/schedulers.py
@@ -7,6 +7,7 @@ import re
 from multiprocessing.util import Finalize
 
 import sqlalchemy as sa
+from sqlalchemy.exc import DBAPIError
 from celery import current_app, schedules
 from celery.beat import ScheduleEntry, Scheduler
 from celery.utils.log import get_logger
@@ -434,7 +435,7 @@ class DatabaseScheduler(Scheduler):
                     update = True
                     # when you updated the `PeriodicTasks` model's `last_update` field
                     logger.info('DatabaseScheduler: Schedule changed.')
-            except sa.exc.DBAPIError as exc:
+            except DBAPIError as exc:
                 logger.exception('Database error while checking if the schedule changed: %r', exc)
 
         if update:


### PR DESCRIPTION
This PR fixes #29 by catching the exception DBAPIerror, thus allowing celery beat to continue working in case the database is not available. 